### PR TITLE
Model to watch

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/src/ng2fittext.directive.ts
+++ b/src/ng2fittext.directive.ts
@@ -10,6 +10,7 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges {
   @Input('container') container: any;
   @Input('activateOnInputEvents') activateOnInputEvents: boolean;
   @Input('useMaxFontSize') useMaxFontSize: boolean;
+  @Input('minFontSize') minFontSize = 7;
   @Input('modelToWatch') modelToWatch: any;
   private maxFontSize: number = 1000;
   private fontSize: number = 0;
@@ -19,6 +20,11 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges {
   }
 
   setFontSize(fontSize) {
+    if (fontSize < this.minFontSize) {
+      // force that font size will never be lower than minimal allowed font size
+      fontSize = this.minFontSize;
+    }
+
     this.fontSize = fontSize;
     return this.el.nativeElement.style.setProperty('font-size', (fontSize).toString() + 'px');
   }
@@ -73,8 +79,11 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges {
       let overflow = this.container ? this.checkOverflow(this.container, this.el.nativeElement)
           : this.checkOverflow(this.el.nativeElement.parentElement, this.el.nativeElement);
       if (overflow) {
-        this.setFontSize(this.calculateFontSize(this.fontSize, this.speed));
-        this.ngAfterViewInit();
+        if (this.fontSize > this.minFontSize) {
+          // iterate only until font size is bigger than minimal value
+          this.setFontSize(this.calculateFontSize(this.fontSize, this.speed));
+          this.ngAfterViewInit();
+        }
       } else {
         if (this.useMaxFontSize) {
           if(this.fontSize > this.maxFontSize) {

--- a/src/ng2fittext.directive.ts
+++ b/src/ng2fittext.directive.ts
@@ -1,15 +1,16 @@
-import {Directive, ElementRef, Renderer, Input, AfterViewInit, HostListener, OnInit} from '@angular/core';
+import {Directive, ElementRef, Renderer, Input, AfterViewInit, HostListener, OnInit, OnChanges, SimpleChanges} from '@angular/core';
 
 @Directive({
   selector: '[fittext]'
 })
-export class Ng2FittextDirective implements AfterViewInit, OnInit {
+export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges {
 
   @Input('fittext') fittext: any;
   @Input('activateOnResize') activateOnResize: boolean;
   @Input('container') container: any;
   @Input('activateOnInputEvents') activateOnInputEvents: boolean;
   @Input('useMaxFontSize') useMaxFontSize: boolean;
+  @Input('modelToWatch') modelToWatch: string;
   private maxFontSize: number = 1000;
   private fontSize: number = 0;
   private speed: number = 1.05;
@@ -38,11 +39,11 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit {
   onResize() {
     if (this.activateOnResize && this.fittext) {
       if (this.activateOnInputEvents && this.fittext) {
-          this.setFontSize(this.container ? this.container.clientHeight : this.el.nativeElement.parentElement.clientHeight);
+        this.setFontSize(this.container ? this.container.clientHeight : this.el.nativeElement.parentElement.clientHeight);
       } else {
         this.setFontSize(this.container ? this.container.clientWidth : this.el.nativeElement.parentElement.clientWidth);
       }
-     
+
       this.ngAfterViewInit();
     }
   }
@@ -50,8 +51,8 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit {
   @HostListener('input', ['$event'])
   onInputEvents() {
     if (this.activateOnInputEvents && this.fittext) {
-        this.setFontSize(this.container ? this.container.clientHeight : this.el.nativeElement.parentElement.clientHeight);
-        this.ngAfterViewInit();
+      this.setFontSize(this.container ? this.container.clientHeight : this.el.nativeElement.parentElement.clientHeight);
+      this.ngAfterViewInit();
     }
   }
 
@@ -70,18 +71,25 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit {
   ngAfterViewInit() {
     if (this.fittext) {
       let overflow = this.container ? this.checkOverflow(this.container, this.el.nativeElement)
-        : this.checkOverflow(this.el.nativeElement.parentElement, this.el.nativeElement);
+          : this.checkOverflow(this.el.nativeElement.parentElement, this.el.nativeElement);
       if (overflow) {
         this.setFontSize(this.calculateFontSize(this.fontSize, this.speed));
         this.ngAfterViewInit();
       } else {
         if (this.useMaxFontSize) {
           if(this.fontSize > this.maxFontSize) {
-              this.maxFontSize = parseInt(window.getComputedStyle(this.container ? this.container : this.el.nativeElement.parentElement).fontSize, null);
-              this.setFontSize(this.maxFontSize);
+            this.maxFontSize = parseInt(window.getComputedStyle(this.container ? this.container : this.el.nativeElement.parentElement).fontSize, null);
+            this.setFontSize(this.maxFontSize);
           }
         }
       }
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.modelToWatch) {
+      // change of model to watch - call ngAfterViewInit where is implemented logic to change size
+      setTimeout(_ => this.ngAfterViewInit() );
     }
   }
 }

--- a/src/ng2fittext.directive.ts
+++ b/src/ng2fittext.directive.ts
@@ -10,7 +10,7 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges {
   @Input('container') container: any;
   @Input('activateOnInputEvents') activateOnInputEvents: boolean;
   @Input('useMaxFontSize') useMaxFontSize: boolean;
-  @Input('modelToWatch') modelToWatch: string;
+  @Input('modelToWatch') modelToWatch: any;
   private maxFontSize: number = 1000;
   private fontSize: number = 0;
   private speed: number = 1.05;


### PR DESCRIPTION
Hi guys,
PR - introduced model (property for directive - **modelToWatch**), when model change -> font size will be recalculated (resolve #8 ).

Example usage :
```
<h1 [fittext]="true"[activateOnResize]="true" [useMaxFontSize]="true" [modelToWatch]="book?.title">
   {{book?.title}}
</h1>
```
Where 'book' is property which is "catched" from some backend (so it is loaded after some time ...).

Also created **'minFontSize'** parameter with default value 7 (resolve #9 ).


----------

! there is one thing which i do not like very much ...
**setTimeout(_ => this.ngAfterViewInit() );**

**Explanation :**
When **model is changed** -> **method 'checkOverflow' is called** -> BUT width / height of children / parent **has old values** (for example, in case of first load everything can be 0 -> because no text has been added to element).

After reading some articles (https://stackoverflow.com/questions/38930183/angular2-expression-has-changed-after-it-was-checked-binding-to-div-width-wi) - it seem like it is nothing special and usage of **setTimeout** is quite normal.

Please, if you have any ideas, feel free to contribute :-)

Martin