### PR TITLE
Set a frame of versions for angular, it works also in angular 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/platform-browser-dynamic": "^4.0.0",
+    "@angular/common": ">=4.0.0 || <6.0.0",
+    "@angular/compiler": ">=4.0.0 || <6.0.0",
+    "@angular/core": ">=4.0.0 || <6.0.0",
+    "@angular/platform-browser": ">=4.0.0 || <6.0.0",
+    "@angular/platform-browser-dynamic": ">=4.0.0 || <6.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
     "zone.js": "0.8.12"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^4.0.0",
+    "@angular/compiler-cli": ">=4.0.0 || <6.0.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "^6.0.42",
     "angular-librarian": "1.0.0-beta.14",


### PR DESCRIPTION
I have set a frame of possible versions of angular. i working with angular 5 and it works fine, but get all the time some dependency warnings. so that should avoid it