### PR TITLE
Fix AOT issue

### DIFF
--- a/src/directives/ng2-fittext.directive.ts
+++ b/src/directives/ng2-fittext.directive.ts
@@ -57,7 +57,7 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges, Af
     }
 
     @HostListener('window:resize', ['$event'])
-    onResize() {
+    onResize(event: Event) {
         this.done = false;
         if (this.activateOnResize && this.fittext) {
             if (this.activateOnInputEvents && this.fittext) {
@@ -71,7 +71,7 @@ export class Ng2FittextDirective implements AfterViewInit, OnInit, OnChanges, Af
     }
 
     @HostListener('input', ['$event'])
-    onInputEvents() {
+    onInputEvents(event: Event) {
         this.done = false;
         if (this.activateOnInputEvents && this.fittext) {
             this.setFontSize(this.getStartFontSizeFromHeight());


### PR DESCRIPTION
This library breaks when running the production build on Angular 8 using AOT, as per https://stackoverflow.com/questions/48163344/angular-aot-error-in-ng-component-html-file-expected-0-arguments-but-got-1/48172467
This is the error: `Ng2FittextDirective, Expected 0 arguments, but got 1.`
This MR fixes this issue.